### PR TITLE
Use 1. for all entries to simplify git diffs

### DIFF
--- a/README_template.md
+++ b/README_template.md
@@ -5,5 +5,5 @@ I manage all of the shipping myself right now, and occasionally get help from a 
 *This page was last generated on {{formatDate date day="numeric" month="long" year="numeric" timeZone="America/New_York"}} at {{formatDate date hour="numeric" minute="numeric" timeZone="America/New_York"}} EST and is updated daily. The Github repo for this page is available here: [https://github.com/olkb/orders](https://github.com/olkb/orders)*
 
 {{#each orders}}
- {{math @index "+" 1}}. {{this.orderNumber}}{{combinedOrders this " combined with "}}
+ 1. {{this.orderNumber}}{{combinedOrders this " combined with "}}
 {{/each}}


### PR DESCRIPTION
I know what you are thinking.... why is there a pull request on my orders repo?

Well, as someone who just ordered a keyboard, this change would
make it much easier for me to see how many orders were completed and how fast the queue is moving.

It will also make it easier to see how many new orders are placed.

The reason is that the diffs between commits each day will not care about the index in the list, only the contents.

This may be a weird request and if you are not interested in it, no worries, just thought it could help.